### PR TITLE
 не показывал кавычки при выводе названий add -r

### DIFF
--- a/stepik-courses.sh
+++ b/stepik-courses.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-curl -s https://stepik.org:443/api/course-lists\?page\=1 | jq
+curl -s https://stepik.org:443/api/course-lists\?page\=1 | jq -r '."course-lists"[].title'


### PR DESCRIPTION
 не показывал кавычки при выводе названий курсов add -r